### PR TITLE
Switch code formatter from Black to Ruff

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	pip install -e .
 
 format:
-	black . -l 79
+	ruff format .
 
 changelog:
 	python .github/bump_version.py

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switched code formatter from Black to Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
-    "black>=23.0.0",
+    "ruff>=0.9.0",
     "towncrier>=24.0.0",
 ]
 
@@ -31,9 +31,6 @@ bump-version = "yaml_changelog.bump:main"
 [project.urls]
 Homepage = "https://github.com/PolicyEngine/yaml-changelog"
 Repository = "https://github.com/PolicyEngine/yaml-changelog"
-
-[tool.black]
-line-length = 79
 
 [tool.hatch.build]
 include = [

--- a/yaml_changelog/build.py
+++ b/yaml_changelog/build.py
@@ -133,9 +133,7 @@ class Changelog:
             try:
                 entry_lines = changelog[start_line:end_line]
                 entry = {}
-                entry["_version"] = (
-                    entry_lines[0].split("[")[1].split("]")[0].strip()
-                )
+                entry["_version"] = entry_lines[0].split("[")[1].split("]")[0].strip()
                 entry["date"] = datetime.fromisoformat(
                     entry_lines[0].split(" - ")[1].strip()
                 )
@@ -179,9 +177,7 @@ class Changelog:
                     current_date = entry["date"]
                 last_date = current_date
 
-        entries = list(
-            sorted(entries, key=lambda x: x.get("date", datetime.now()))
-        )
+        entries = list(sorted(entries, key=lambda x: x.get("date", datetime.now())))
 
         for i in range(1, len(entries)):
             version = entries[i]["_version"]
@@ -209,9 +205,7 @@ class Changelog:
         md_entries = []
         links = []
         version = VersionNumber()
-        entries = sorted(
-            self.entries, key=lambda x: x.get("date", datetime.now())
-        )
+        entries = sorted(self.entries, key=lambda x: x.get("date", datetime.now()))
         for i in range(len(entries)):
             print("debug: ", entries[i])
             entry = entries[i]
@@ -258,9 +252,7 @@ class Changelog:
 def main():
     parser = ArgumentParser()
     parser.add_argument("file", help="File to parse.")
-    parser.add_argument(
-        "--append-file", help="File to append to the main YAML file."
-    )
+    parser.add_argument("--append-file", help="File to append to the main YAML file.")
     parser.add_argument("--org", help="Organization to use for GitHub links.")
     parser.add_argument("--repo", help="Repo to link to.")
     parser.add_argument(

--- a/yaml_changelog/bump.py
+++ b/yaml_changelog/bump.py
@@ -3,9 +3,7 @@ from yaml_changelog.build import Changelog
 
 
 def main():
-    parser = ArgumentParser(
-        description="Bump version numbers from changelog.yaml"
-    )
+    parser = ArgumentParser(description="Bump version numbers from changelog.yaml")
     parser.add_argument("changelog_file", help="Path to changelog.yaml")
     parser.add_argument(
         "files", nargs="*", help="Paths to files to bump version numbers in"
@@ -14,16 +12,12 @@ def main():
 
     changelog = Changelog(args.changelog_file)
     changelog._write_to_md()
-    print(
-        f"Bumping from {changelog.previous_version} to {changelog.current_version}"
-    )
+    print(f"Bumping from {changelog.previous_version} to {changelog.current_version}")
 
     for file in args.files:
         with open(file, "r") as f:
             content = f.read()
-        content = content.replace(
-            changelog.previous_version, changelog.current_version
-        )
+        content = content.replace(changelog.previous_version, changelog.current_version)
         with open(file, "w") as f:
             f.write(content)
 


### PR DESCRIPTION
## Summary
- Replace Black with Ruff (`ruff>=0.9.0`) in dev dependencies
- Remove `[tool.black]` configuration section from `pyproject.toml`
- Update `Makefile` format target: `black . -l 79` -> `ruff format .`
- Reformat all Python files with Ruff defaults (88 char line length)

## Test plan
- [x] `ruff format --check .` passes (4 files formatted)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)